### PR TITLE
Use PDNS_CHECK_CDB to check for cdb lib instead of PKG_CHECK_MODULES

### DIFF
--- a/pdns/dnsdistdist/m4/dnsdist_enable_namedcache.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_enable_namedcache.m4
@@ -9,13 +9,6 @@ AC_DEFUN([DNSDIST_ENABLE_NAMEDCACHE], [
   AM_CONDITIONAL([NAMEDCACHE], [test "x$enable_namedcache" != "xno"])
 
   AM_COND_IF([NAMEDCACHE], [
-    PKG_CHECK_MODULES([TINYCDB], [libcdb], [
-      AC_DEFINE([HAVE_NAMEDCACHE], [1], [Define to 1 if you have namedCache & libtinycdb])
-      CFLAGS="$LIBTINYCDB_CFLAGS $CFLAGS"
-      LIBS="$LIBTINYCDB_LIBS $LIBS"
-    ],[
-      AC_MSG_ERROR([libtinycdb requested but not available])
-    ])
+      PDNS_CHECK_CDB
   ])
-
 ])

--- a/pdns/dnsdistdist/m4/pdns_check_cdb.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_cdb.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_check_cdb.m4


### PR DESCRIPTION
### Short description
`PKG_CHECK_MODULES` was causing an error during `configure` because the `tinycdb` did not have a `pkg-config` file.
